### PR TITLE
BUGFIX re #18455  - WCF Service Discovery Announment crashes ECS

### DIFF
--- a/src/ServiceModel/ServiceModel/ServiceModel/Discovery/AnnouncementService.cs
+++ b/src/ServiceModel/ServiceModel/ServiceModel/Discovery/AnnouncementService.cs
@@ -60,8 +60,16 @@ namespace EMG.Utilities.ServiceModel.Discovery
 
                     if (metadata != null)
                     {
-                        client.AnnounceOnline(metadata);
-                        _logger.LogTrace($"[{endpoint.Contract.ContractType}] Announced {endpoint.Address.Uri} to {_options.RegistryUri}");
+                        try
+                        {
+                            client.AnnounceOnline(metadata);
+                            _logger.LogTrace(
+                                $"[{endpoint.Contract.ContractType}] Announced {endpoint.Address.Uri} to {_options.RegistryUri}");
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex, $"Failed to announce [{endpoint.Contract.ContractType}] service to {_options.RegistryUri}: {ex}");
+                        }
                     }
                 }
             });
@@ -79,10 +87,16 @@ namespace EMG.Utilities.ServiceModel.Discovery
 
                         if (metadata != null)
                         {
-                            client.AnnounceOffline(metadata);
-                            _logger.LogTrace($"Unannounced {endpoint.Address.Uri} to {_options.RegistryUri}");
+                            try
+                            {
+                                client.AnnounceOffline(metadata);
+                                _logger.LogTrace($"Unannounced {endpoint.Address.Uri} to {_options.RegistryUri}");
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogWarning(ex, $"Failed to announce [{endpoint.Contract.ContractType}] service to {_options.RegistryUri}: {ex}");
+                            }
                         }
-
                     }
                 }
             }

--- a/src/ServiceModel/ServiceModel/ServiceModel/Discovery/DefaultAnnouncementClientWrapper.cs
+++ b/src/ServiceModel/ServiceModel/ServiceModel/Discovery/DefaultAnnouncementClientWrapper.cs
@@ -1,0 +1,30 @@
+using System;
+using System.ServiceModel.Discovery;
+
+namespace EMG.Utilities.ServiceModel.Discovery
+{
+    public class DefaultAnnouncementClientWrapper : IAnnouncementClientWrapper
+    {
+        private readonly AnnouncementClient _client;
+
+        public DefaultAnnouncementClientWrapper(AnnouncementClient client)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        public void AnnounceOnline(EndpointDiscoveryMetadata metadata)
+        {
+            _client.AnnounceOnline(metadata);
+        }
+
+        public void AnnounceOffline(EndpointDiscoveryMetadata metadata)
+        {
+            _client.AnnounceOffline(metadata);
+        }
+
+        public void Dispose()
+        {
+            ((IDisposable)_client).Dispose();
+        }
+    }
+}

--- a/src/ServiceModel/ServiceModel/ServiceModel/Discovery/DefaultAnnouncementClientWrapperFactory.cs
+++ b/src/ServiceModel/ServiceModel/ServiceModel/Discovery/DefaultAnnouncementClientWrapperFactory.cs
@@ -1,0 +1,21 @@
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Discovery;
+
+namespace EMG.Utilities.ServiceModel.Discovery
+{
+    public class DefaultAnnouncementClientWrapperFactory : IAnnouncementClientWrapperFactory
+    {
+        public IAnnouncementClientWrapper Create(Uri registryUrl, Binding binding)
+        {
+            var endpointAddress = new EndpointAddress(registryUrl);
+            var endpoint = new AnnouncementEndpoint(binding, endpointAddress);
+            var client = new AnnouncementClient(endpoint);
+
+            var wrapper = new DefaultAnnouncementClientWrapper(client);
+
+            return wrapper;
+        }
+    }
+}

--- a/src/ServiceModel/ServiceModel/ServiceModel/Discovery/IAnnouncementClientWrapper.cs
+++ b/src/ServiceModel/ServiceModel/ServiceModel/Discovery/IAnnouncementClientWrapper.cs
@@ -1,0 +1,12 @@
+using System;
+using System.ServiceModel.Discovery;
+
+namespace EMG.Utilities.ServiceModel.Discovery
+{
+    public interface IAnnouncementClientWrapper : IDisposable
+    {
+        public void AnnounceOnline(EndpointDiscoveryMetadata metadata);
+
+        public void AnnounceOffline(EndpointDiscoveryMetadata metadata);
+    }
+}

--- a/src/ServiceModel/ServiceModel/ServiceModel/Discovery/IAnnouncementClientWrapperFactory.cs
+++ b/src/ServiceModel/ServiceModel/ServiceModel/Discovery/IAnnouncementClientWrapperFactory.cs
@@ -1,0 +1,10 @@
+using System;
+using System.ServiceModel.Channels;
+
+namespace EMG.Utilities.ServiceModel.Discovery
+{
+    public interface IAnnouncementClientWrapperFactory
+    {
+        IAnnouncementClientWrapper Create(Uri registryUrl, Binding binding);
+    }
+}

--- a/src/ServiceModel/ServiceModel/ServiceModel/ServiceCollectionExtensions.cs
+++ b/src/ServiceModel/ServiceModel/ServiceModel/ServiceCollectionExtensions.cs
@@ -70,10 +70,11 @@ namespace EMG.Utilities.ServiceModel
                 options.Binding = binding;
             });
 
+            services.AddSingleton<IAnnouncementClientWrapperFactory, DefaultAnnouncementClientWrapperFactory>();
+
             services.AddSingleton<IAnnouncementService, AnnouncementService>();
 
             return services;
         }
-
     }
 }

--- a/tests/Tests.ServiceModel/ServiceModel/Discovery/AnnouncementServiceTests.cs
+++ b/tests/Tests.ServiceModel/ServiceModel/Discovery/AnnouncementServiceTests.cs
@@ -74,9 +74,11 @@ namespace Tests.ServiceModel.Discovery
 
             Mock.Get(clientFactory).Setup(i => i.Create(It.IsAny<Uri>(), It.IsAny<Binding>())).Returns(clientWrapper);
 
-            Assert.DoesNotThrow(() => sut.AnnounceEndpoints(new[] {testEndpoint}));
-
-            scheduler.AdvanceBy(options.Interval.Ticks);
+            Assert.DoesNotThrow(() =>
+            {
+                sut.AnnounceEndpoints(new[] {testEndpoint});
+                scheduler.AdvanceBy(options.Interval.Ticks);
+            });
         }
 
         [Test, CustomAutoData]

--- a/tests/Tests.ServiceModel/ServiceModel/Discovery/AnnouncementServiceTests.cs
+++ b/tests/Tests.ServiceModel/ServiceModel/Discovery/AnnouncementServiceTests.cs
@@ -1,12 +1,19 @@
-﻿using System;
+﻿using AutoFixture.Idioms;
+using AutoFixture.NUnit3;
+using EMG.Utilities.ServiceModel.Discovery;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Reactive.Testing;
+using Moq;
+using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.ServiceModel;
+using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
-using AutoFixture.Idioms;
-using AutoFixture.NUnit3;
-using EMG.Utilities.ServiceModel.Discovery;
-using NUnit.Framework;
+using System.ServiceModel.Discovery;
+using AnnouncementService = EMG.Utilities.ServiceModel.Discovery.AnnouncementService;
 
 namespace Tests.ServiceModel.Discovery
 {
@@ -43,6 +50,59 @@ namespace Tests.ServiceModel.Discovery
             var disposable = sut.AnnounceEndpoints(new[] { testEndpoint });
 
             disposable.Dispose();
+        }
+
+        [Test, CustomAutoData]
+        public void AnnounceEndpoints_suppress_exceptions_for_AnnounceOnline(
+            [Frozen] AnnouncementServiceOptions options,
+            IAnnouncementClientWrapper clientWrapper,
+            [Frozen] IAnnouncementClientWrapperFactory clientFactory,
+            ILogger<AnnouncementService> logger, ServiceEndpoint testEndpoint, Uri endpointUri)
+        {
+            options.EndpointDiscoveryMetadata = (_) => new EndpointDiscoveryMetadata();
+            options.Interval = TimeSpan.FromSeconds(1);
+            options.IsAnnouncementEnabled = true;
+
+            testEndpoint.Address = new EndpointAddress(endpointUri);
+            testEndpoint.Behaviors.Add(new AnnounceableBehavior());
+
+            var scheduler = new TestScheduler();
+
+            var sut = new AnnouncementService(new OptionsWrapper<AnnouncementServiceOptions>(options), logger, clientFactory, scheduler);
+
+            Mock.Get(clientWrapper).Setup(i => i.AnnounceOnline(It.IsAny<EndpointDiscoveryMetadata>())).Throws<Exception>();
+
+            Mock.Get(clientFactory).Setup(i => i.Create(It.IsAny<Uri>(), It.IsAny<Binding>())).Returns(clientWrapper);
+
+            Assert.DoesNotThrow(() => sut.AnnounceEndpoints(new[] {testEndpoint}));
+
+            scheduler.AdvanceBy(options.Interval.Ticks);
+        }
+
+        [Test, CustomAutoData]
+        public void AnnounceEndpoints_suppress_exceptions_for_AnnounceOffline(
+            [Frozen] AnnouncementServiceOptions options,
+            IAnnouncementClientWrapper clientWrapper,
+            [Frozen] IAnnouncementClientWrapperFactory clientFactory,
+            ServiceEndpoint testEndpoint, Uri endpointUri,
+            AnnouncementService sut)
+        {
+            options.EndpointDiscoveryMetadata = (_) => new EndpointDiscoveryMetadata();
+            options.IsAnnouncementEnabled = true;
+
+            testEndpoint.Address = new EndpointAddress(endpointUri);
+            testEndpoint.Behaviors.Add(new AnnounceableBehavior());
+
+            Mock.Get(clientWrapper).Setup(i => i.AnnounceOffline(It.IsAny<EndpointDiscoveryMetadata>())).Throws<Exception>();
+
+            Mock.Get(clientFactory).Setup(i => i.Create(It.IsAny<Uri>(), It.IsAny<Binding>())).Returns(clientWrapper);
+
+            Assert.DoesNotThrow(() =>
+            {
+                var subscription = sut.AnnounceEndpoints(new[] {testEndpoint});
+                subscription.Dispose();
+            });
+
         }
     }
 }

--- a/tests/Tests.ServiceModel/Tests.ServiceModel.csproj
+++ b/tests/Tests.ServiceModel/Tests.ServiceModel.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,6 +21,7 @@
 
   <ItemGroup>
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ServiceModel.Discovery" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added try catch for announce/unannounce and added warning logging instead of throwing exceptions