### PR TITLE
COREX-1392 migrate static images - Update package icon

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/emgdev/dotnet-utils</PackageProjectUrl>
-    <PackageIconUrl>http://static.emg-services.net/masterpages/pics/logos/emg-icon-64.png</PackageIconUrl>
+    <PackageIconUrl>https://cdn-static.emg-services.net/masterpages/pics/logos/emg-icon-64.png</PackageIconUrl>
     <NoWarn>NU5105,NU5125,NU5048</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
Moved package icon to emg-static bucket